### PR TITLE
[Pandemonium] Make it really obvious that this platform is homebrew in the exporter

### DIFF
--- a/export/export.cpp
+++ b/export/export.cpp
@@ -149,11 +149,11 @@ public:
 	}
 
 	virtual String get_name() const {
-		return "Nintendo Switch";
+		return "Nintendo Switch (Homebrew)";
 	}
 
 	virtual String get_os_name() const {
-		return "Switch";
+		return "SwitchHB";
 	}
 
 	virtual Ref<Texture> get_logo() const {


### PR DESCRIPTION
Not sure whether you guys would want this or not, but in case you do, here it is.

It just adds "(Homebrew)" to the end of the exporter's full name, an "HB" to the exporter's platform name.

(This is for the Pandemonium branch)